### PR TITLE
Introduce ZABBIX_TESTSUITE_PREFIX variable

### DIFF
--- a/_batch_csv_to_png.sh
+++ b/_batch_csv_to_png.sh
@@ -8,8 +8,6 @@ for i in `cat $METRIC_META_FILE`; do
 		metric_meta=(`echo $i | tr ";" " "`)
 		metric_request_type=${metric_meta[0]}
 		metric_name=${metric_meta[1]}
-		metric_name_caps=`echo $metric_name | tr /a-z/ /A-Z/ | sed -e 's,-,_,g'`
-		zabbix_metric_prefix="$JOB_BASE_NAME.$metric_request_type.$metric_name"
 
 		#@@GENERATE_CSV_TO_PNG@@
 		for c in $(find $LOG_DIR/csv -name '*.csv' | grep "\-$metric_request_type\_$metric_name"); do

--- a/_batch_distribution_to_csv.sh
+++ b/_batch_distribution_to_csv.sh
@@ -18,8 +18,6 @@ for i in `cat $METRIC_META_FILE`; do
 		metric_meta=(`echo $i | tr ";" " "`)
 		metric_request_type=${metric_meta[0]}
 		metric_name=${metric_meta[1]}
-		metric_name_caps=`echo $metric_name | tr /a-z/ /A-Z/ | sed -e 's,-,_,g'`
-		zabbix_metric_prefix="$JOB_BASE_NAME.$metric_request_type.$metric_name"
 
 		for c in $(find $LOG_DIR/csv -name '*-report_distribution.csv'); do
 			distribution_2_csv $c "$metric_request_type $metric_name";

--- a/_batch_locust_log_to_csv.sh
+++ b/_batch_locust_log_to_csv.sh
@@ -8,8 +8,6 @@ for i in `cat $METRIC_META_FILE`; do
 		metric_meta=(`echo $i | tr ";" " "`)
 		metric_request_type=${metric_meta[0]}
 		metric_name=${metric_meta[1]}
-		metric_name_caps=`echo $metric_name | tr /a-z/ /A-Z/ | sed -e 's,-,_,g'`
-		zabbix_metric_prefix="$JOB_BASE_NAME.$metric_request_type.$metric_name"
 
 		#@@GENERATE_LOCUST_LOG_TO_CSV@@
 		$COMMON/_locust-log-to-csv.sh "$metric_request_type $metric_name" $LOG_DIR/$JOB_BASE_NAME-$BUILD_NUMBER-locust-master.log

--- a/_batch_results_report.sh
+++ b/_batch_results_report.sh
@@ -13,8 +13,7 @@ for i in `cat $METRIC_META_FILE`; do
 		metric_meta=(`echo $i | tr ";" " "`)
 		metric_request_type=${metric_meta[0]}
 		metric_name=${metric_meta[1]}
-		metric_name_caps=`echo $metric_name | tr /a-z/ /A-Z/ | sed -e 's,-,_,g'`
-		zabbix_metric_prefix="$JOB_BASE_NAME.$metric_request_type.$metric_name"
+		zabbix_metric_prefix="$ZABBIX_TESTSUITE_PREFIX.$metric_request_type.$metric_name"
 
 		#@@GENERATE_FILTER_ZABBIX_VALUE@@
 		V_MIN=`filterZabbixValue $ZABBIX_LOG "$zabbix_metric_prefix-rt_min"`;

--- a/_batch_zabbix_process_load.sh
+++ b/_batch_zabbix_process_load.sh
@@ -9,8 +9,7 @@ for i in `cat $METRIC_META_FILE`; do
 		metric_meta=(`echo $i | tr ";" " "`)
 		metric_request_type=${metric_meta[0]}
 		metric_name=${metric_meta[1]}
-		metric_name_caps=`echo $metric_name | tr /a-z/ /A-Z/ | sed -e 's,-,_,g'`
-		zabbix_metric_prefix="$JOB_BASE_NAME.$metric_request_type.$metric_name"
+		zabbix_metric_prefix="$ZABBIX_TESTSUITE_PREFIX.$metric_request_type.$metric_name"
 
 		#@@GENERATE_ZABBIX_PROCESS_LOAD@@
 		$COMMON/__zabbix-process-load.sh "\"$metric_request_type\",\"$metric_name\"" "$zabbix_metric_prefix" >> $ZABBIX_LOG

--- a/config/_setenv.sh
+++ b/config/_setenv.sh
@@ -62,6 +62,10 @@ export ENV_FILE=${ENV_FILE:-/tmp/osioperftest.users.env}
 # A hostname in Zabbix the report is for
 #export ZABBIX_HOST=qa_openshift.io
 
+# A prefix for the zabbix metric names.
+# (default value is equal to $JOB_BASE_NAME)
+export ZABBIX_TESTSUITE_PREFIX=${ZABBIX_TESTSUITE_PREFIX:-$JOB_BASE_NAME}
+
 # A number of seconds for how long the test should run
 #export DURATION=60
 


### PR DESCRIPTION
... To optionally specify zabbix metric prefix not based on job name.

The default value is the value of `JOB_BASE_NAME` variable.